### PR TITLE
Shutdown sanlock on HE hosts before the shutdown

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,7 +60,7 @@
 
     - set_fact:
         he_shutdown_cmd: >-
-          while hosted-engine --vm-status | grep "\"vm\": \"up\"" >/dev/null; do sleep 5; done; shutdown -h now
+          while hosted-engine --vm-status | grep "\"vm\": \"up\"" >/dev/null; do sleep 5; done; sanlock client shutdown -f 1; shutdown -h now
         non_he_noipmi_shutdown_cmd: >-
           while pgrep qemu-kvm >/dev/null; do sleep 5; done; shutdown -h now
         gmaintenance_mode_cmd: >-


### PR DESCRIPTION
Shutdown sanlock on HE hosts before the shutdown
to cleanly remove sanlock locks.
Non HE hosts are already in maintenance mode
so nothing is needed there.