### PR TITLE
Other ansible28 fixes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,12 +48,12 @@
     - name: Define a query for HE hosts
       set_fact:
         he_hosts: >-
-          {{ ovirt_host | selectattr('hosted_engine', 'defined') | selectattr('hosted_engine.configured') | list }}
+          {{ ovirt_hosts | selectattr('hosted_engine', 'defined') | selectattr('hosted_engine.configured') | list }}
 
     - name: Define a query for non HE hosts
       set_fact:
         non_he_hosts: >-
-          {{ ovirt_host | difference(he_hosts) }}
+          {{ ovirt_hosts | difference(he_hosts) }}
 
     - name: Define a query for non HE hosts with power management
       set_fact:
@@ -68,7 +68,7 @@
     - name: Define a query for hosts with power management
       set_fact:
         hosts_ipmi: >-
-          {{ ovirt_host | selectattr('power_management', 'defined') | selectattr('power_management.enabled') | list }}
+          {{ ovirt_hosts | selectattr('power_management', 'defined') | selectattr('power_management.enabled') | list }}
 
     - name: Define commands
       set_fact:
@@ -99,7 +99,7 @@
             wait: true
           when: "item.origin != 'managed_hosted_engine'"
           with_items:
-            - "{{ ovirt_vm }}"
+            - "{{ ovirt_vms }}"
           ignore_errors: true
 
         - name: Refresh VM list
@@ -116,7 +116,7 @@
             force: true
           when: "item.origin != 'managed_hosted_engine' and item.status != 'down'"
           with_items:
-            - "{{ ovirt_vm }}"
+            - "{{ ovirt_vms }}"
 
         - name: Shutdown hosts, except HE ones, via IPMI (if configured)
           ovirt_host:


### PR DESCRIPTION
ovirt modele names will be in the singular form
while the returned values will be in plural one.