### PR TITLE
Parallelize the shutdown of VMs

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 host_names:
   - '*'
+vm_shutdown_timeout: 300
+vm_shutdown_poll_interval: 15
+vm_shutdown_batch_count: 10

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,15 +92,11 @@
 
     - block:
         - name: Shutdown all VMs, except HostedEngine
-          ovirt_vm:
-            state: stopped
-            name: "{{ item.name }}"
-            auth: "{{ ovirt_auth }}"
-            wait: true
-          when: "item.origin != 'managed_hosted_engine'"
+          include_tasks: shutdown_vm.yml
+          vars:
+            vm_list: "{{ item }}"
           with_items:
-            - "{{ ovirt_vms }}"
-          ignore_errors: true
+            - "{{ ovirt_vms | batch(vm_shutdown_batch_count) | list }}"
 
         - name: Refresh VM list
           ovirt_vm_facts:

--- a/tasks/shutdown_vm.yml
+++ b/tasks/shutdown_vm.yml
@@ -1,0 +1,24 @@
+---
+- name: Shutdown VMs in batches
+  ovirt_vm:
+    state: stopped
+    name: "{{ batch_vm.name }}"
+    auth: "{{ ovirt_auth }}"
+    wait: true
+  when: "batch_vm.origin != 'managed_hosted_engine'"
+  loop_control:
+    loop_var: "batch_vm"
+  ignore_errors: true
+  poll: 0
+  async: "{{ vm_shutdown_timeout }}"
+  register: shutdown_vm
+  with_items: "{{ vm_list }}"
+
+- name: Wait for the shutdown of VMs
+  async_status: "jid={{ item.ansible_job_id }}"
+  register: job_result
+  with_items: "{{ shutdown_vm.results }}"
+  until: job_result.finished
+  retries: "{{ vm_shutdown_timeout // vm_shutdown_poll_interval }}"
+  delay: "{{ vm_shutdown_poll_interval }}"
+  ignore_errors: true


### PR DESCRIPTION
Currently, the shutdown process of VMs can take a very long time for
large environment since the task wait for the VM to go down before
shutting down the next. Here the shutdown is Parallelized and wait
for default timeout of 300 seconds before forcefully powering off
the VMs.