### PR TITLE
automation: drop dead distributions

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,5 +1,4 @@
 distros:
-  - fc29
   - fc30
   - el7
 release_branches:


### PR DESCRIPTION
dropped fc29 which reached EOL status.